### PR TITLE
Cache weather screen data

### DIFF
--- a/SPHA/screens/WeatherScreen.cpp
+++ b/SPHA/screens/WeatherScreen.cpp
@@ -4,40 +4,23 @@
 #include "../StorageManager.h"
 
 WeatherScreen::WeatherScreen(StorageManager* storage) : storage(storage) {
-  // Constructor implementation
+  refresh();
 }
 
 void WeatherScreen::draw(ScreenManager* manager) {
   manager->setFont(u8g2_font_6x12_tf);
   manager->clearBuffer();
 
-  String json = storage->getItem("ha_sensors", "[]");
-  StaticJsonDocument<1024> doc;
-  DeserializationError error = deserializeJson(doc, json);
-  if (error) {
-    manager->drawStr(0, 15, "Failed to parse sensors");
+  if (sensors.empty()) {
+    manager->drawStr(0, 15, "No data");
     manager->sendBuffer();
     return;
   }
 
   int y = 14;
-  for (JsonObject item : doc.as<JsonArray>()) {
-    String title = item["title"] | "";
-    String value;
-
-    if (item["value"].is<JsonArray>()) {
-      JsonArray arr = item["value"].as<JsonArray>();
-      for (int i = 0; i < arr.size(); ++i) {
-        value += String(arr[i].as<const char*>());
-        if (i < arr.size() - 1) value += ", ";
-      }
-    } else {
-      value = item["value"].as<String>();
-    }
-
-    String unit = item["unit"] | "";
-    String line = title + ": " + value;
-    if (unit.length()) line += " " + unit;
+  for (const auto& item : sensors) {
+    String line = item.title + ": " + item.value;
+    if (item.unit.length()) line += " " + item.unit;
 
     manager->drawStr(0, y, line.c_str());
     y += 12;
@@ -49,4 +32,31 @@ void WeatherScreen::draw(ScreenManager* manager) {
 
 const char* WeatherScreen::getTitle() {
   return "Weather";
+}
+
+void WeatherScreen::refresh() {
+  sensors.clear();
+
+  String json = storage->getItem("ha_sensors", "[]");
+  StaticJsonDocument<1024> doc;
+  DeserializationError error = deserializeJson(doc, json);
+  if (error) return;
+
+  for (JsonObject item : doc.as<JsonArray>()) {
+    WeatherData data;
+    data.title = item["title"].as<String>();
+
+    if (item["value"].is<JsonArray>()) {
+      JsonArray arr = item["value"].as<JsonArray>();
+      for (int i = 0; i < arr.size(); ++i) {
+        data.value += String(arr[i].as<const char*>());
+        if (i < arr.size() - 1) data.value += ", ";
+      }
+    } else {
+      data.value = item["value"].as<String>();
+    }
+
+    data.unit = item["unit"].as<String>();
+    sensors.push_back(data);
+  }
 }

--- a/SPHA/screens/WeatherScreen.h
+++ b/SPHA/screens/WeatherScreen.h
@@ -5,15 +5,24 @@
 #include "IScreen.h"
 #include "../StorageManager.h"
 #include <ArduinoJson.h>
+#include <vector>
+
+struct WeatherData {
+  String title;
+  String value;
+  String unit;
+};
 
 class WeatherScreen : public IScreen {
 public:
   explicit WeatherScreen(StorageManager* storage);
   void draw(ScreenManager* manager) override;
   const char* getTitle() override;
+  void refresh();
 
 private:
   StorageManager* storage;
+  std::vector<WeatherData> sensors;
 };
 
 #endif // WEATHER_SCREEN_H


### PR DESCRIPTION
## Summary
- cache weather data instead of parsing JSON each draw
- add a refresh method for updating cached data

## Testing
- `g++ -std=c++17 -c SPHA/screens/WeatherScreen.cpp` *(fails: Arduino.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_687617b6b8208320ba743e3b25e529d1