### PR TITLE
Fix SettingsScreen interface

### DIFF
--- a/SPHA/ScreenManager.cpp
+++ b/SPHA/ScreenManager.cpp
@@ -144,3 +144,11 @@ void ScreenManager::drawDisc(int x, int y, int r) {
 void ScreenManager::drawCircle(int x, int y, int r) {
   display.drawCircle(x, y, r);
 }
+
+void ScreenManager::setDrawColor(uint8_t color) {
+  display.setDrawColor(color);
+}
+
+void ScreenManager::drawBox(int x, int y, int w, int h) {
+  display.drawBox(x, y, w, h);
+}

--- a/SPHA/ScreenManager.h
+++ b/SPHA/ScreenManager.h
@@ -40,4 +40,6 @@ public:
   int getStrWidth(const char* text);
   void drawDisc(int x, int y, int r);
   void drawCircle(int x, int y, int r);
+  void setDrawColor(uint8_t color);
+  void drawBox(int x, int y, int w, int h);
 };

--- a/SPHA/screens/SettingsScreen.cpp
+++ b/SPHA/screens/SettingsScreen.cpp
@@ -1,4 +1,5 @@
 #include "SettingsScreen.h"
+#include "../ScreenManager.h"
 
 SettingsScreen::SettingsScreen(StorageManager* storage) : storage(storage) {
   options.push_back({
@@ -20,9 +21,9 @@ const char* SettingsScreen::getTitle() {
   return "Settings";
 }
 
-void SettingsScreen::draw(U8G2* display) {
-  display->setFont(u8g2_font_6x10_tf);
-  display->clearBuffer();
+void SettingsScreen::draw(ScreenManager* manager) {
+  manager->setFont(u8g2_font_6x10_tf);
+  manager->clearBuffer();
 
   for (int i = 0; i < options.size(); ++i) {
     String label = options[i].label;
@@ -34,17 +35,17 @@ void SettingsScreen::draw(U8G2* display) {
     int y = 12 * (i + 1);
 
     if (i == selectedIndex) {
-      display->setDrawColor(1);       // Белый фон
-      display->drawBox(0, y - 10, 128, 12);
-      display->setDrawColor(0);       // Чёрный текст
-      display->drawStr(2, y, line.c_str());
-      display->setDrawColor(1);       // Вернуть цвет текста
+      manager->setDrawColor(1);       // Белый фон
+      manager->drawBox(0, y - 10, 128, 12);
+      manager->setDrawColor(0);       // Чёрный текст
+      manager->drawStr(2, y, line.c_str());
+      manager->setDrawColor(1);       // Вернуть цвет текста
     } else {
-      display->drawStr(2, y, line.c_str());
+      manager->drawStr(2, y, line.c_str());
     }
   }
 
-  display->sendBuffer();
+  manager->sendBuffer();
 }
 
 void SettingsScreen::onRotate(int direction) {
@@ -66,11 +67,11 @@ void SettingsScreen::onRotate(int direction) {
   }
 }
 
-void SettingsScreen::onClick() {
+void SettingsScreen::onRotaryClick() {
   editing = !editing;
 }
 
-void SettingsScreen::onDoubleClick() {
+void SettingsScreen::onRotaryDoubleClick() {
   for (const auto& option : options) {
     String rawValue = option.isBool ? (option.value == "On" ? "true" : "false") : option.value;
     storage->setItem(option.key, rawValue);

--- a/SPHA/screens/SettingsScreen.h
+++ b/SPHA/screens/SettingsScreen.h
@@ -15,7 +15,7 @@ class SettingsScreen : public IScreen {
 public:
   explicit SettingsScreen(StorageManager* storage);
   const char* getTitle() override;
-  void draw(U8G2* display) override;
+  void draw(ScreenManager* manager) override;
   void onRotate(int direction) override;
   void onRotaryClick() override;
   void onRotaryDoubleClick() override;


### PR DESCRIPTION
## Summary
- update `SettingsScreen` to implement `draw(ScreenManager*)`
- rename click handlers to `onRotaryClick` and `onRotaryDoubleClick`
- expose `setDrawColor` and `drawBox` helpers on `ScreenManager`

## Testing
- `apt-get update` *(fails: mise.jdx.dev blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687617b0b970832083cddf8e75a0d00b