### PR TITLE
Fix missing semicolons in ScreenManager

### DIFF
--- a/SPHA/ScreenManager.cpp
+++ b/SPHA/ScreenManager.cpp
@@ -18,8 +18,8 @@ ScreenManager::ScreenManager(StorageManager* storage, BatteryManager* battery, T
       screens.push_back(new ClockScreen(time));
 
       if (storage->isKeySetAndNotEmpty("ha_endpoint") && storage->isKeySetAndNotEmpty("ha_ip") && storage->isKeySetAndNotEmpty("ha_token")) {
-        Serial.println("HA integration is setup, add sensor screen")
-        screens.push_back(new SensorScreen(storage))
+        Serial.println("HA integration is setup, add sensor screen");
+        screens.push_back(new SensorScreen(storage));
       }
     }
 


### PR DESCRIPTION
## Summary
- add missing semicolons in ScreenManager.cpp

## Testing
- `apt-get update`
- `g++ -c SPHA/ScreenManager.cpp -o /tmp/screen_manager.o` *(fails: `U8g2lib.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687617aac6008320a34027361fe04bf9